### PR TITLE
Cleanup/round1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -553,7 +553,7 @@ ul {
   align-items: center;
   padding: .75rem 1.75rem .6rem;
   overflow: hidden;
-  transition: background 300ms, color 300ms, fill 300ms, padding 300ms;
+  transition: background-color 300ms ease-out, color 300ms ease-out, fill 300ms ease-out, padding 300ms ease-out;
   border: solid 3px #012939;
   background: #012939;
   box-shadow: none;
@@ -604,6 +604,83 @@ ul {
 .button--ghost:hover, .button--ghost:active, .button--ghost:focus, .button--ghost[aria-selected='true'] {
   background-color: #012939;
   color: #fff;
+}
+
+/***** Tables *****/
+.article-body table {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-spacing: 0;
+  border-collapse: collapse;
+  box-shadow: 2px 2px 4px rgba(204, 204, 204, 0.15);
+  vertical-align: top;
+  margin-top: 32px;
+  margin-bottom: 32px;
+  white-space: nowrap;
+}
+
+@media screen and (min-width: 320px) {
+  .article-body table {
+    margin-top: calc(32px + 16 * ( 100vw - 320px ) / 1046);
+  }
+}
+
+@media screen and (min-width: 1366px) {
+  .article-body table {
+    margin-top: 48px;
+  }
+}
+
+@media screen and (min-width: 320px) {
+  .article-body table {
+    margin-bottom: calc(32px + 16 * ( 100vw - 320px ) / 1046);
+  }
+}
+
+@media screen and (min-width: 1366px) {
+  .article-body table {
+    margin-bottom: 48px;
+  }
+}
+
+.article-body th {
+  border: solid 1px #888;
+  padding: 5px;
+  background-color: #f3f3f3;
+  font-weight: 700;
+  line-height: 1em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+@media screen and (min-width: 320px) {
+  .article-body th {
+    padding: calc(5px + 5 * ( 100vw - 320px ) / 1046);
+  }
+}
+
+@media screen and (min-width: 1366px) {
+  .article-body th {
+    padding: 10px;
+  }
+}
+
+.article-body td {
+  border: solid 1px #888;
+  padding: 5px;
+}
+
+@media screen and (min-width: 320px) {
+  .article-body td {
+    padding: calc(5px + 5 * ( 100vw - 320px ) / 1046);
+  }
+}
+
+@media screen and (min-width: 1366px) {
+  .article-body td {
+    padding: 10px;
+  }
 }
 
 /* stylelint-disable */
@@ -1060,7 +1137,9 @@ ul {
 }
 
 .footer__logo {
+  max-width: 242px;
   height: 40px;
+  color: #fff;
 }
 
 .footer__logo-link {
@@ -1070,11 +1149,6 @@ ul {
 
 .footer__logo-link:hover, .footer__logo-link:focus, .footer__logo-link:active {
   box-shadow: none;
-}
-
-.footer__logo {
-  max-width: 242px;
-  color: #fff;
 }
 
 @media print {
@@ -1132,6 +1206,12 @@ ul {
 @media (min-width: 768px) {
   .footer-column__title {
     margin-top: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .footer-column__inner:not(:first-child) {
+    margin-left: 15px;
   }
 }
 
@@ -1326,7 +1406,7 @@ ul {
   padding: 0;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .breadcrumbs {
     margin: 0;
   }
@@ -1342,7 +1422,7 @@ ul {
   text-overflow: ellipsis;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .breadcrumbs li {
     max-width: 450px;
   }
@@ -1374,10 +1454,24 @@ ul {
   height: 40px;
   padding-right: 20px;
   padding-left: 40px;
+  font-size: 16px;
   transition: border 300ms ease-out, color 300ms ease-out;
   border: 3px solid #ddd;
+  border-radius: 0;
   color: #999;
   -webkit-appearance: none;
+}
+
+@media screen and (min-width: 320px) {
+  .search input[type='search'] {
+    font-size: calc(16px + 4 * ( 100vw - 320px ) / 1046);
+  }
+}
+
+@media screen and (min-width: 1366px) {
+  .search input[type='search'] {
+    font-size: 20px;
+  }
 }
 
 [dir='rtl'] .search input[type='search'] {
@@ -1429,6 +1523,7 @@ ul {
   height: 50px;
   transition: border 300ms ease-out, color 300ms ease-out;
   border: 5px solid #e9e9e9;
+  border-radius: 0;
   color: #012939;
   font-family: "Poppins", "Poppins";
   font-weight: 800;
@@ -1687,14 +1782,14 @@ ul {
   padding-bottom: 15px;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .sub-nav {
     flex-direction: row;
     align-items: baseline;
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .sub-nav input[type='search'] {
     min-width: 300px;
   }
@@ -2052,6 +2147,10 @@ ul {
   }
 }
 
+.article-list__item {
+  margin: 15px 0;
+}
+
 /***** Section pages *****/
 .section:not(.hero):not(.knowledge-base) {
   padding-bottom: 72px;
@@ -2073,6 +2172,10 @@ ul {
   .section:not(.hero):not(.knowledge-base)::after {
     content: 'Please visit help.getjobber.com for updated documents';
   }
+}
+
+.article-list__item {
+  margin: 15px 0;
 }
 
 /***** Article *****/
@@ -2271,7 +2374,11 @@ ul {
   color: #fff;
 }
 
-.article-vote:hover::before, .article-vote:hover::after, .article-vote[aria-selected='true']::before, .article-vote[aria-selected='true']::after, .article-vote[aria-selected='true'] {
+.article-vote:hover::before, .article-vote:hover::after {
+  color: #fff;
+}
+
+.article-vote[aria-selected='true']::before, .article-vote[aria-selected='true']::after, .article-vote[aria-selected='true'] {
   background-color: #012939;
   color: #fff;
 }
@@ -2297,6 +2404,10 @@ ul {
   .article-more-questions {
     display: none;
   }
+}
+
+.article-more-questions__paragraph {
+  margin: 0;
 }
 
 .article-return-to-top {
@@ -2868,8 +2979,8 @@ ul {
 @media (min-width: 768px) {
   .jobber-mid-cta .container {
     display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     width: 93%;
   }
 }
@@ -5561,39 +5672,35 @@ html[lang|='zh'] .search-results-description em {
   padding-left: 0;
 }
 
-.article-body .accordion-section {
+.article-body .accordion-section:not(:first-child) {
   margin-top: 32px;
   margin-bottom: 32px;
 }
 
 @media screen and (min-width: 320px) {
-  .article-body .accordion-section {
+  .article-body .accordion-section:not(:first-child) {
     margin-top: calc(32px + 16 * ( 100vw - 320px ) / 1046);
   }
 }
 
 @media screen and (min-width: 1366px) {
-  .article-body .accordion-section {
+  .article-body .accordion-section:not(:first-child) {
     margin-top: 48px;
   }
 }
 
 @media screen and (min-width: 320px) {
-  .article-body .accordion-section {
+  .article-body .accordion-section:not(:first-child) {
     margin-bottom: calc(32px + 16 * ( 100vw - 320px ) / 1046);
   }
 }
 
 @media screen and (min-width: 1366px) {
-  .article-body .accordion-section {
+  .article-body .accordion-section:not(:first-child) {
     margin-bottom: 48px;
   }
 }
 
 .article-body .accordion-title {
   text-transform: none;
-}
-
-.article-body table {
-  display: none;
 }

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -159,7 +159,10 @@
   }
 
   &:hover::before,
-  &:hover::after,
+  &:hover::after {
+    color: $white;
+  }
+
   &[aria-selected='true']::before,
   &[aria-selected='true']::after,
   &[aria-selected='true'] {
@@ -185,6 +188,10 @@
   font-size: 16px;
   @media print {
     display: none;
+  }
+
+  &__paragraph {
+    margin: 0;
   }
 }
 

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -2,7 +2,7 @@
 .breadcrumbs {
   margin: 0 0 30px;
   padding: 0;
-  @include tablet {
+  @include desktop {
     margin: 0;
   }
 
@@ -14,7 +14,7 @@
     font-size: $font-size-small;
     font-weight: $font-weight-light;
     text-overflow: ellipsis;
-    @include tablet {
+    @include desktop {
       max-width: 450px;
     }
 

--- a/styles/_buttons.scss
+++ b/styles/_buttons.scss
@@ -6,10 +6,10 @@
   padding: .75rem 1.75rem .6rem;
   overflow: hidden;
   transition:
-    background $transition-speed,
-    color $transition-speed,
-    fill $transition-speed,
-    padding $transition-speed;
+    background-color $transition-speed ease-out,
+    color $transition-speed ease-out,
+    fill $transition-speed ease-out,
+    padding $transition-speed ease-out;
   border: solid 3px $primary;
   background: $primary;
   box-shadow: none;

--- a/styles/_category.scss
+++ b/styles/_category.scss
@@ -32,3 +32,9 @@
 );
   font-weight: $font__weight--bold;
 }
+
+.article-list {
+  &__item {
+    margin: $spacing 0;
+  }
+}

--- a/styles/_footer.scss
+++ b/styles/_footer.scss
@@ -64,6 +64,12 @@
       margin-top: 0;
     }
   }
+
+  &__inner:not(:first-child) {
+    @include tablet {
+      margin-left: $spacing;
+    }
+  }
 }
 
 .footer-list {

--- a/styles/_search.scss
+++ b/styles/_search.scss
@@ -8,10 +8,17 @@
     height: 40px;
     padding-right: 20px;
     padding-left: 40px;
+    @include fluid-value( font-size,
+    $min-width,
+    $max-width,
+    $base-font-size,
+    $base-font-size--desktop
+  );
     transition:
       border $transition-speed ease-out,
       color $transition-speed ease-out;
     border: 3px solid $border-color;
+    border-radius: 0;
     color: $field-text-color;
     -webkit-appearance: none;
 
@@ -62,6 +69,7 @@
     border $transition-speed ease-out,
     color $transition-speed ease-out;
   border: 5px solid $grey--lighter;
+  border-radius: 0;
   color: $primary;
   font-family: $font--heading;
   font-weight: $font__weight--extra-bold;

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -12,3 +12,9 @@
     }
   }
 }
+
+.article-list {
+  &__item {
+    margin: $spacing 0;
+  }
+}

--- a/styles/_sub-nav.scss
+++ b/styles/_sub-nav.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable */
 .sub-nav {
-  @include tablet {
+  @include desktop {
     flex-direction: row;
     align-items: baseline;
   }
@@ -13,7 +13,7 @@
 
   //Inner pages search field
   input[type='search'] {
-    @include tablet {
+    @include desktop {
       min-width: 300px;
     }
 

--- a/styles/_tables.scss
+++ b/styles/_tables.scss
@@ -1,41 +1,42 @@
-/* stylelint-disable */
 /***** Tables *****/
-.table {
-  @include tablet { table-layout: auto; }
-  width: 100%;
-  table-layout: fixed;
-
-  th,
-  th a {
-    color: $secondary-text-color;
-    font-size: $font-size-small;
-    font-weight: $font-weight-light;
-    text-align: left;
-
-    [dir='rtl'] & { text-align: right; }
+.article-body {
+  table {
+    display: inline-block;
+    max-width: 100%;
+    overflow-x: auto;
+    border-spacing: 0;
+    border-collapse: collapse;
+    box-shadow: 2px 2px 4px hsla(0, 0%, 80%, .15);
+    vertical-align: top;
+    // TODO: Finish styling table pivot
+    @include fluid-value( margin-top,
+    $min-width,
+    $max-width,
+    $whitespace-small,
+    $whitespace-small--desktop
+  );
+    @include fluid-value( margin-bottom,
+    $min-width,
+    $max-width,
+    $whitespace-small,
+    $whitespace-small--desktop
+  );
+    // optional - looks better for small cell values
+    white-space: nowrap;
   }
 
-  tr {
-    @include tablet { display: table-row; }
-    display: block;
-    padding: 20px 0;
-    border-bottom: 1px solid $border-color;
+  th {
+    border: solid $border--width $grey--light;
+    @include fluid-value( padding, $min-width, $max-width, 5px, 10px );
+    background-color: $grey--lightest;
+    font-weight: $font__weight--bold;
+    line-height: 1em;
+    text-align: left;
+    text-transform: uppercase;
   }
 
   td {
-    @include tablet {
-      display: table-cell;
-    }
-    display: block;
-  }
-
-  td, th {
-    @include desktop {
-      padding: 20px 30px;
-    }
-    @include tablet {
-      height: 60px;
-      padding: 10px 20px;
-    }
+    border: solid $border--width $grey--light;
+    @include fluid-value( padding, $min-width, $max-width, 5px, 10px );
   }
 }

--- a/styles/_wysiwyg.scss
+++ b/styles/_wysiwyg.scss
@@ -223,7 +223,7 @@
     }
   }
 
-  .accordion-section {
+  .accordion-section:not(:first-child) {
     @include fluid-value( margin-top,
     $min-width,
     $max-width,
@@ -242,6 +242,4 @@
     @extend .h3;
     text-transform: none;
   }
-
-  table { display: none; }
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -2,7 +2,7 @@
 @import 'mixins';
 @import 'base';
 @import 'buttons';
-// @import 'tables';
+@import 'tables';
 @import 'forms';
 @import 'highlight-text';
 @import 'header';

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -18,27 +18,13 @@
   <div class="container">
     <nav class="sub-nav">
       {{breadcrumbs}}
-      {{search scoped=settings.scoped_kb_search submit=false}}
+      {{search submit=false instant=settings.instant_search placeholder='Search the Help Center'}}
     </nav>
     <section class="article-info">
       <aside class="article-sidebar">
       </aside>
       <div class="article-content">
         <div class="article-body">{{article.body}}</div>
-
-        <div class="article-attachments">
-          <ul class="attachments">
-            {{#each attachments}}
-              <li class="attachment-item">
-                <a href="{{url}}" target="_blank">{{name}}</a>
-                <div class="attachment-meta meta-group">
-                  <span class="attachment-meta-item meta-data">{{size}}</span>
-                  <a href="{{url}}" target="_blank" class="attachment-meta-item meta-data">Download</a>
-                </div>
-              </li>
-            {{/each}}
-          </ul>
-        </div>
       </div>
     </section>
 
@@ -70,7 +56,9 @@
       {{/with}}
 
       <div class="article-more-questions">
-        <a  href="javascript:Intercom('showNewMessage');">Still have questions?</a>
+        <p class="article-more-questions__paragraph">Still have questions?
+          <a  href="javascript:Intercom('showNewMessage');">Start a chat.</a>
+        </p>
       </div>
       <div class="article-return-to-top">
         <a class="noshadow" href="#top">{{t 'return_to_top'}}<span class="icon-arrow-up"></span></a>

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -3,7 +3,7 @@
     <div class="container">
     <h1 class="h2 page-header__title">{{category.name}}
       {{#if category.description}}
-        <div class="page-header__description">{{category.description}}</div>
+        <span class="page-header__description">{{category.description}}</span>
       {{/if}}
     </h1>
     </div>

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -13,7 +13,7 @@
     <div class="container">
       <nav class="sub-nav">
         {{breadcrumbs}}
-        {{search submit=false}}
+        {{search submit=false instant=settings.instant_search placeholder='Search the Help Center'}}
       </nav>
       <div class="section-tree">
         {{#each sections}}

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -1,6 +1,6 @@
 <section class="section hero community-hero">
   <div class="hero-inner">
-    {{search submit=false class='search search-full' scoped=settings.scoped_community_search}}
+    {{search submit=false class='search' instant=settings.instant_search placeholder='Search the Help Center'}}
   </div>
 </section>
 

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -2,7 +2,7 @@
 <div class="container">
   <nav class="sub-nav">
     {{breadcrumbs}}
-    {{search scoped=settings.scoped_community_search submit=false}}
+    {{search scoped=settings.scoped_community_search submit=false placeholder='Search the Help Center'}}
   </nav>
 
   <div class="post-container">

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -1,6 +1,6 @@
 <section class="section hero community-hero">
   <div class="hero-inner">
-    {{search submit=false class='search search-full' scoped=settings.scoped_community_search}}
+    {{search submit=false class='search' scoped=settings.scoped_community_search}}
   </div>
 </section>
 

--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -1,7 +1,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
-<link href="https://fonts.googleapis.com/css?family=Poppins:400,800,900|Source+Sans+Pro:400,700&display=swap" rel="stylesheet dns-prefetch">
+<link href="https://fonts.googleapis.com/css?family=Poppins:400,800,900%7CSource+Sans+Pro:400,700&display=swap" rel="stylesheet dns-prefetch">
 <meta name="theme-color" content="#ffffff">
 <meta name="apple-mobile-web-app-title" content="Jobber Help Center">
 <meta name="application-name" content="Jobber Help Center">
@@ -9,16 +9,8 @@
 <script async defer src="https://d3ey4dbjkt2f6s.cloudfront.net/source_tracking.js"></script>
 <script async defer src="https://secure.getjobber.com/website_js.js"></script>
 <!-- Google Tag Manager -->
-<script type="text/javascript">
-    var dataLayer = [];
-</script>
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-T5PQR7"
-                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+<script>var dataLayer = [];</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-T5PQR7');</script>
 <!-- End Google Tag Manager -->
-
-

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -16,7 +16,7 @@
       </button>
       <nav class="user-nav" id="user-nav">
         <a class="user-nav__link" href="https://getjobber.com">Back to Jobber</a>
-        <a class="button button--ghost user-nav__link" href="javascript:Intercom('showNewMessage');" role="button">Chat Now</a class="user-nav__link">
+        <a class="button button--ghost user-nav__link" href="javascript:Intercom('showNewMessage');" role="button">Chat Now</a>
       </nav>
     </div>
   </div>

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -20,11 +20,10 @@
   </div>
 </section>
 
-
 <div class="knowledge-base__wrapper">
   <section class="container section knowledge-base">
     <h2 class="knowledge-base__title">Learn about our features</h2>
-    <section class="categories blocks">
+    <div class="categories blocks">
       <ul class="blocks__list">
         {{#each categories}}
           {{#if ../has_multiple_categories}}
@@ -38,9 +37,7 @@
             {{#each sections}}
               <li class="blocks__item">
                 <a href='{{url}}' class="blocks__item-link">
-                  <span class="blocks__item-title">
-                    {{name}}
-                  </span>
+                  <span class="blocks__item-title">{{name}}</span>
                   <span class="blocks__item-description">{{excerpt description}}</span>
                 </a>
               </li>
@@ -49,13 +46,14 @@
         {{/each}}
       </ul>
       {{pagination}}
-    </section>
+    </div>
+  </section>
 </div>
 
 <div class="jobber-resources__wrapper">
   <section class="container jobber-resources">
     <h2 class="jobber-resources__title">Jobber Resources</h2>
-    <section class="jobber-resources-cards">
+    <div class="jobber-resources-cards">
       <div class="jobber-resources-card">
         <figure class="jobber-resources-card__image">
           <img src="{{ asset 'thumb_glossary.png' }}" alt="A white Jobber logo on a navy background">
@@ -98,7 +96,7 @@
           Learn more
         </a>
       </div>
-    </section>
+    </div>
   </section>
 </div>
 

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -2,7 +2,7 @@
 <div class="container">
   <nav class="sub-nav">
     {{breadcrumbs}}
-    {{search submit=false}}
+    {{search submit=false placeholder='Search the Help Center'}}
   </nav>
 
   <h1>

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -2,7 +2,7 @@
 <div class="container">
   <nav class="sub-nav">
     {{breadcrumbs}}
-    {{search submit=false}}
+    {{search submit=false class='search' instant=settings.instant_search placeholder='Search the Help Center'}}
   </nav>
 
   <div class="search-results">
@@ -101,7 +101,7 @@
                   </li>
                   <li class="meta-data">{{date edited_at format='short'}}</li>
                 </ul>
-                <div class="search-results-description">{{text}}</div>
+                <div class="search-results-description">{{text}}...</div>
               </article>
             </li>
           {{/each}}

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -18,7 +18,7 @@
       {{#if section.sections}}
         <ul class="section-list section-list--collapsed">
           {{#each section.sections}}
-          <li class="section-list-item">
+            <li class="section-list-item">
               <a href="{{url}}">
                 <span>{{name}}</span>
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" aria-hidden="true">
@@ -27,10 +27,9 @@
               </a>
             </li>
           {{/each}}
-          <a tabindex="0" class="see-all-sections-trigger" aria-hidden="true" id="see-all-sections-trigger" title="{{t 'see_all_sections'}}">{{t 'see_all_sections'}}</a>
+          <li><a tabindex="0" class="see-all-sections-trigger" aria-hidden="true" id="see-all-sections-trigger" title="{{t 'see_all_sections'}}">{{t 'see_all_sections'}}</a></li>
         </ul>
       {{/if}}
-
       {{#if section.articles}}
         <ul class="article-list">
           {{#each section.articles}}
@@ -48,6 +47,7 @@
         </i>
       {{/if}}
       {{pagination}}
-    </section>
-  </div>
+    </div>
+  </section>
 </div>
+


### PR DESCRIPTION
## What was done
- [ ] Searches are all instant with lookahead
- [ ] Search placeholder text now consistent
- [ ] ellipses after search results
- [ ] removed attachments at bottom of articles
- [ ] search bar on internal pages has bigger font
- [ ] border radius on search inputs explicitly set to 0 for ios devices
- [ ] gutter added to footer links
- [ ] spacing on category/section links increased
- [ ] vote button hover state smoothed out
- [ ] breadcrumb/search on interior pages now stays on two lines until desktop
- [ ] first accordion section does not have a margin
- [ ] Still have questions was changed to include start a chat
- [ ] Edited the still need help chat link on articles
- [ ] responsive table (To see go here: https://help.getjobber.com/hc/en-us/articles/360039475854 )