### PR TITLE
Update the footer year from 2019 to 2020

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -124,7 +124,7 @@
     <div class="footer-copyright">
       <ul class="footer-copyright__list">
         <li class="footer-copyright__item">
-          &copy; Jobber Copyright 2019
+          &copy; Jobber Copyright 2020
         </li>
         <li class="footer-copyright__item">
           <a class="footer-copyright__link" href="https://getjobber.com/privacy-policy/" rel="noopener noreferrer" target="_blank">Privacy</a>


### PR DESCRIPTION
The year in the footer still said 2019. Changed it to 2020.

Asana task: https://app.asana.com/0/1164538569125870/1184142470601409/f

![Screen Shot 2020-08-10 at 3 34 02 PM](https://user-images.githubusercontent.com/1953515/89833810-eecaee80-db1e-11ea-9286-bc3b7bcd1abc.png)
