### PR TITLE
Update instagram url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -138,4 +138,4 @@
       </ul>
     </div>
   </div>
-</footer
+</footer>

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -78,7 +78,7 @@
                 </a>
               </li>
               <li class="footer-social__item">
-                <a class="footer-social__link" href="https://www.instagram.com/getjobber/" target="_blank" rel="noopener noreferrer">
+                <a class="footer-social__link" href="https://www.instagram.com/jobber/" target="_blank" rel="noopener noreferrer">
                   <svg class="footer-social__icon  footer-social__icon--instagram" viewBox="0 0 56.7 56.7" xmlns="http://www.w3.org/2000/svg"><title>Link to GetJobber Instagram</title><path d="M28.2 16.7c-7 0-12.8 5.7-12.8 12.8s5.7 12.8 12.8 12.8S41 36.5 41 29.5s-5.8-12.8-12.8-12.8zm0 21c-4.5 0-8.2-3.7-8.2-8.2s3.7-8.2 8.2-8.2 8.2 3.7 8.2 8.2-3.7 8.2-8.2 8.2z"/><circle cx="41.5" cy="16.4" r="2.9"/><path d="M49 8.9c-2.6-2.7-6.3-4.1-10.5-4.1H17.9c-8.7 0-14.5 5.8-14.5 14.5v20.5c0 4.3 1.4 8 4.2 10.7 2.7 2.6 6.3 3.9 10.4 3.9h20.4c4.3 0 7.9-1.4 10.5-3.9 2.7-2.6 4.1-6.3 4.1-10.6V19.3c0-4.2-1.4-7.8-4-10.4zm-.4 31c0 3.1-1.1 5.6-2.9 7.3s-4.3 2.6-7.3 2.6H18c-3 0-5.5-.9-7.3-2.6C8.9 45.4 8 42.9 8 39.8V19.3c0-3 .9-5.5 2.7-7.3 1.7-1.7 4.3-2.6 7.3-2.6h20.6c3 0 5.5.9 7.3 2.7 1.7 1.8 2.7 4.3 2.7 7.2v20.6z" fill="#99A9B0" fill-rule="evenodd"/></svg>
                 </a>
               </li>
@@ -138,4 +138,4 @@
       </ul>
     </div>
   </div>
-</footer>
+</footer


### PR DESCRIPTION
This updates the URL of our hardcoded Instagram links. To test, pull and build the Help Center theme and confirm that clicking the Instagram icon takes you to the correct URL.