### PR TITLE
Add a11y link to the footer and update copyright year

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -124,10 +124,13 @@
     <div class="footer-copyright">
       <ul class="footer-copyright__list">
         <li class="footer-copyright__item">
-          &copy; Jobber Copyright 2020
+          &copy; Jobber Copyright 2021
         </li>
         <li class="footer-copyright__item">
           <a class="footer-copyright__link" href="https://getjobber.com/privacy-policy/" rel="noopener noreferrer" target="_blank">Privacy</a>
+        </li>
+        <li class="footer-copyright__item">
+          <a class="footer-copyright__link" href="https://getjobber.com/accessibility-policy/" rel="noopener noreferrer" target="_blank">Accessibility</a>
         </li>
         <li class="footer-copyright__item">
           <a class="footer-copyright__link" href="https://getjobber.com/terms-of-service/" rel="noopener noreferrer" target="_blank">Terms of Service</a>


### PR DESCRIPTION
This PR updates the copyright year, and adds  an 'Accessibility' link in the footer which takes users to our Accessibility Policy. 

To test, confirm that the copyright year has been updated to 2021, and the 'Accessibility' link takes users to the correct page on getjobber.com 