### PR TITLE
Update the copyright year in the footer

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -124,7 +124,7 @@
     <div class="footer-copyright">
       <ul class="footer-copyright__list">
         <li class="footer-copyright__item">
-          &copy; Jobber Copyright 2021
+          &copy; Jobber Copyright 2022
         </li>
         <li class="footer-copyright__item">
           <a class="footer-copyright__link" href="https://getjobber.com/privacy-policy/" rel="noopener noreferrer" target="_blank">Privacy</a>


### PR DESCRIPTION
This updates the hardcoded copyright year in the footer of the Help Center theme. To test, pull and build and confirm you're seeing 'Copyright 2022'.