### PR TITLE
add component names to maintenance messages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -224,7 +224,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         var statusTitle = (data.incidents.length) ? 'SERVICE DISRUPTION' : 'SCHEDULED MAINTENANCE';
-        var maintenance_message =  typeof maintenance_component_name !== 'undefined' ? 'Jobber&rsquo;s ' + maintenance_component_name + ' is undergoing scheduled maintenance right now. Thank you for your patience.'  : 'Jobber is undergoing scheduled maintenance right now. Thank you for your patience. '
+        var maintenance_message =  typeof maintenance_component_name !== 'undefined' ? 'We&rsquo;re doing scheduled maintenance on our ' + maintenance_component_name + ' right now. Thank you for your patience.'  : 'Jobber is undergoing scheduled maintenance right now. Thank you for your patience. '
         var statusBody = (data.incidents.length) ? 'Some parts of Jobber are currently down. We’re sorry for the inconvenience, and we’re working to get things back up and running ASAP.' : maintenance_message;
         document.getElementById("jobbar-banner").innerHTML = '<div class="container jobbar-banner__container"><div class="jobbar-banner__content"><div>'+statusTitle+'</div><div class="jobbar-banner__subtitle">'+statusBody+'</div></div><a href="https://www.jobberstatus.net/" class="button">LEARN MORE</a></div>';
         document.getElementById("jobbar-banner").style.display = "flex";

--- a/script.js
+++ b/script.js
@@ -208,12 +208,24 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // display a message if jobberstatus.net is reporting maintenance or an outage
   var sp = new StatusPage.page({ page : '7qns4hqkcjx5' });
+  // var sp = new StatusPage.page({ page : 'p2lpv5tmvf9q' }); //'Statusbar Test' dev account
   sp.summary({
     success: function (data) {
       var statusIndicator = data.status.indicator;
       if(data.incidents.length || statusIndicator === 'maintenance'){
+
+        var maintenance_component_name;
+        if (statusIndicator === 'maintenance'){
+          data.components.forEach(component => {
+            if (component.status == 'under_maintenance') {
+              maintenance_component_name = component.name;
+            }
+          });
+        }
+
         var statusTitle = (data.incidents.length) ? 'SERVICE DISRUPTION' : 'SCHEDULED MAINTENANCE';
-        var statusBody = (data.incidents.length) ? 'Some parts of Jobber are currently down. We’re sorry for the inconvenience, and we’re working to get things back up and running ASAP.' : 'Jobber is undergoing scheduled maintenance right now. Thank you for your patience. ';
+        var maintenance_message =  typeof maintenance_component_name !== 'undefined' ? 'Jobber&rsquo;s ' + maintenance_component_name + ' is undergoing scheduled maintenance right now. Thank you for your patience.'  : 'Jobber is undergoing scheduled maintenance right now. Thank you for your patience. '
+        var statusBody = (data.incidents.length) ? 'Some parts of Jobber are currently down. We’re sorry for the inconvenience, and we’re working to get things back up and running ASAP.' : maintenance_message;
         document.getElementById("jobbar-banner").innerHTML = '<div class="container jobbar-banner__container"><div class="jobbar-banner__content"><div>'+statusTitle+'</div><div class="jobbar-banner__subtitle">'+statusBody+'</div></div><a href="https://www.jobberstatus.net/" class="button">LEARN MORE</a></div>';
         document.getElementById("jobbar-banner").style.display = "flex";
       }


### PR DESCRIPTION
This updates the help sites outage banner to name the component that is under maintenance when maintenance happens.
 Task: https://app.asana.com/0/1164538569125870/1201179706866017/f

Before:
During scheduled maintenance, the help banner would say "Jobber is undergoing scheduled maintenance right now. Thank you for your patience."

After:
The help banner says (for example)  "Jobber's Text Messaging Service is undergoing scheduled maintenance right now. Thank you for your patience."

To test: 

- Update the js file to point to the test statuspage account by uncommenting line 211.
- Go to https://manage.statuspage.io/login?redirect=%2Fpages%2Fp2lpv5tmvf9q%2Fcomponents (login with "Statuspage test" in lastpass.
- Edit a component and change the status to "Under Maintenance"
- Check that the banner uses the name of the component in the outage message 