### PR TITLE
Open category links in a new page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -16,9 +16,7 @@
         {{search submit=false instant=settings.instant_search placeholder='Search the Help Center'}}
       </nav>
 
-        {{#is 115001344107 category.id }}
-            {{section_tree_with_article}}
-        {{else}}
+
           <div class="section-tree">
             {{#each sections}}
               <section class="section-tree__section">
@@ -49,8 +47,6 @@
               </i>
             {{/each}}
           </div>
-
-        {{/is}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
This removes the AJAX loading from https://help.getjobber.com/hc/en-us/categories/115001344107-Notifications 

## Steps to test
* Build the code
* Go to https://help.getjobber.com/hc/en-us/categories/115001344107-Notifications 
* Click on any of the links under 'TWO-WAY TEXT MESSAGING' or 'NOTIFICATIONS' and confirm they open in a new page.

