### PR TITLE
add js for copyright year

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -127,7 +127,7 @@
     <div class="footer-copyright">
       <ul class="footer-copyright__list">
         <li class="footer-copyright__item">
-          &copy; Jobber Copyright 2023
+          &copy; Jobber Copyright <script>document.write(new Date().getFullYear())</script>
         </li>
         <li class="footer-copyright__item">
           <a class="footer-copyright__link" href="https://getjobber.com/privacy-policy/" rel="noopener noreferrer" target="_blank">Privacy</a>


### PR DESCRIPTION
This updates the method for the copyright year on the help site. It's already live, this PR just keeps the repo in sync with production.