### PR TITLE
WSO-5493 move element in template

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.47",
+  "version": "2.0.48",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -24,6 +24,18 @@
       <aside class="article-sidebar">
       </aside>
       <div class="article-content">
+        {{#with article}}
+          <div class="article-votes">
+            <h4 class="article-votes-question">{{t 'was_this_article_helpful'}}</h4>
+            <small class="article-votes-count">
+              {{vote 'label' class='article-vote-label'}}
+            </small>
+            <div class="article-votes-controls" role='radiogroup'>
+              {{vote 'up' role='radio' class='button article-vote article-vote-up'}}
+              {{vote 'down' role='radio' class='button article-vote article-vote-down'}}
+            </div>
+          </div>
+        {{/with}}
         <div class="article-body">{{article.body}}</div>
       </div>
     </section>
@@ -42,18 +54,6 @@
           {{/if}}
         {{/if}}
       </div>
-      {{#with article}}
-        <div class="article-votes">
-          <h4 class="article-votes-question">{{t 'was_this_article_helpful'}}</h4>
-          <small class="article-votes-count">
-            {{vote 'label' class='article-vote-label'}}
-          </small>
-          <div class="article-votes-controls" role='radiogroup'>
-            {{vote 'up' role='radio' class='button article-vote article-vote-up'}}
-            {{vote 'down' role='radio' class='button article-vote article-vote-down'}}
-          </div>
-        </div>
-      {{/with}}
 
       <div class="article-more-questions">
         <p class="article-more-questions__paragraph">Still have questions?
@@ -78,7 +78,7 @@
 <div class="jobber-mid-cta">
   <section class="container">
     <div class="jobber-mid-cta__content">
-      <div class="jobber-mid-cta__pre-title">WE’RE HERE TO HELP</div>
+      <div class="jobber-mid-cta__pre-title">WE'RE HERE TO HELP</div>
       <div class="jobber-mid-cta__title h3"><span class="highlight-text">Talk to a real person.</span> <br /> No matter the question.</div>
     </div>
     <div class="jobber-mid-cta__action">


### PR DESCRIPTION
This moves the "Was this article helpful?" component to the top of help center articles, as requested by Sarah King.

[Asana](https://app.asana.com/1/58812369999730/project/290831939083027/task/1210394105743840?focus=true)

Before

![image](https://github.com/user-attachments/assets/23dcd1d9-712f-41ba-981f-b15f8b635ccc)
![image](https://github.com/user-attachments/assets/b2aa2088-2ebc-48b9-a885-d28e5531df0e)


After

![image](https://github.com/user-attachments/assets/c730abac-ec3d-44d3-aad7-5c0903fee5e2)


To test

If you have active Zendesk credentials,[ follow this guide](https://jobber.atlassian.net/wiki/spaces/MAR/pages/3325591824/How+to+Make+changes+to+help.getjobber.com) to preview this in your local environment. Otherwise, I can demo my local on a call, or we can bypass testing since this is a very basic change.