### PR TITLE
replace "real person" copy

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Help GetJobber 2019",
   "author": "Jobber",
-  "version": "2.0.48",
+  "version": "2.0.49",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -79,7 +79,7 @@
   <section class="container">
     <div class="jobber-mid-cta__content">
       <div class="jobber-mid-cta__pre-title">WE'RE HERE TO HELP</div>
-      <div class="jobber-mid-cta__title h3"><span class="highlight-text">Talk to a real person.</span> <br /> No matter the question.</div>
+      <div class="jobber-mid-cta__title h3"><span class="highlight-text">Fast answers,</span> <br /> whenever you need them.</div>
     </div>
     <div class="jobber-mid-cta__action">
       <a class="button jobber-mid-cta__link" href="https://getjobber.com/contact/" target="_blank">Contact Us</a>

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -54,7 +54,7 @@
   <section class="container">
     <div class="jobber-mid-cta__content">
       <div class="jobber-mid-cta__pre-title">WE’RE HERE TO HELP</div>
-      <div class="jobber-mid-cta__title h3"><span class="highlight-text">Talk to a real person.</span> <br /> No matter the question.</div>
+      <div class="jobber-mid-cta__title h3"><span class="highlight-text">Fast answers,</span> <br /> whenever you need them.</div>
     </div>
     <div class="jobber-mid-cta__action">
       <a class="button jobber-mid-cta__link" href="https://getjobber.com/contact/" target="_blank">Contact Us</a>

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -107,7 +107,7 @@
   <section class="container">
     <div class="jobber-mid-cta__content">
       <div class="jobber-mid-cta__pre-title">WE’RE HERE TO HELP</div>
-      <div class="jobber-mid-cta__title h3"><span class="highlight-text">Talk to a real person.</span> <br /> No matter the question.</div>
+      <div class="jobber-mid-cta__title h3"><span class="highlight-text">Fast answers,</span> <br /> whenever you need them.</div>
     </div>
     <div class="jobber-mid-cta__action">
       <a class="button jobber-mid-cta__link" href="https://getjobber.com/contact/" target="_blank">Contact Us</a>


### PR DESCRIPTION
## Summary

Updates the support CTA copy across the Help Center site templates to align with new messaging approved by the team.

**Copy change:**
- From: *"Talk to a real person. No matter the question."*
- To: *"Fast answers, whenever you need them."*

## What changed

The mid-CTA section ("WE'RE HERE TO HELP") appeared identically in three page templates. All three have been updated:

- `templates/article_page.hbs`
- `templates/category_page.hbs`
- `templates/home_page.hbs`

## Context

Part of a broader copy update to support-related messaging across Jobber's web properties (WSO-12195). The Contact Us page update was handled separately via CMS. This PR covers the Help Center side, which required a theme/template change.

Asana task: https://app.asana.com/1/58812369999730/project/1213471799133578/task/1214582605682105

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214610261853184